### PR TITLE
Bug fix: Creating a new object instance causes a DoesNotExist exception

### DIFF
--- a/save_the_change/mixins.py
+++ b/save_the_change/mixins.py
@@ -51,7 +51,7 @@ class BaseChangeTracker(object):
 		
 		"""
 		
-		if hasattr(self, '_changed_fields') and self.id is not None:
+		if hasattr(self, '_changed_fields') and self.pk is not None:
 			try:
 				name_map = self._meta._name_map
 			


### PR DESCRIPTION
This prevents a DoesNotExists exception when creating a new instance rather than editing an existing one
