### PR TITLE
check for force_save, force_update

### DIFF
--- a/save_the_change/decorators.py
+++ b/save_the_change/decorators.py
@@ -114,6 +114,8 @@ def _save_the_change_save_hook(instance, *args, **kwargs):
 		hasattr(instance, '_mutable_fields') and
 		'update_fields' not in kwargs and
 		not kwargs.get('force_insert', False) and
+		not kwargs.get('force_update', False) and
+		not kwargs.get('force_save', False) and
 		instance._meta.pk.attname not in instance._changed_fields
 	):
 		kwargs['update_fields'] = (


### PR DESCRIPTION
I noticed that STC respects force_insert but  was not supporting force_update. I have also included a check for "force_save" which is a way to bypass the save check completely.

Use case for this:
I have fields that are managed by django-fsm (https://github.com/kmmbvnr/django-fsm)
when using STC after a state transition the save() function cancels out here. If there is a way to bypass the check it should cover all third party integrations.